### PR TITLE
Refactor session store usage in router and API interceptor

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -5,6 +5,8 @@ import AlertsView from '@/views/AlertsView.vue'
 import { createRouter, createWebHistory } from 'vue-router'
 import { useSessionStore } from '@/store/auth.store'
 
+const sessionStore = useSessionStore()
+
 const router = createRouter({
   history: createWebHistory(),
   routes: [
@@ -16,7 +18,6 @@ const router = createRouter({
       path: '/admin',
       component: AdminView,
       beforeEnter: () => {
-        const sessionStore = useSessionStore()
         return sessionStore.isLoggedIn;
       },
     },

--- a/src/services/BackendService.ts
+++ b/src/services/BackendService.ts
@@ -1,3 +1,4 @@
+import { useSessionStore } from '@/store/auth.store'
 import axios from 'axios'
 
 const Api = axios.create({
@@ -7,6 +8,9 @@ const Api = axios.create({
   maxBodyLength: 100000000,
 })
 
+const sessionStore = useSessionStore()
+
+
 const getToken = () => {
   const token = localStorage.getItem('ACCESS_TOKEN')
   return token ? JSON.parse(token) : null
@@ -14,7 +18,7 @@ const getToken = () => {
 
 Api.interceptors.request.use((config) => {
   if (config.headers['Require-Auth'] !== false) {
-    const token = getToken()
+    const token = sessionStore.token || getToken()
     if (token) {
       config.headers.Authorization = `Bearer ${token}`
     }

--- a/src/store/auth.store.ts
+++ b/src/store/auth.store.ts
@@ -39,5 +39,4 @@ export const useSessionStore = defineStore(SESSION_STORE, {
     isLoggedIn: (state) => state.authenticated && state.user,
     fullname: (state) => state.user?.name || '',
   },
-  persist: true,
 })


### PR DESCRIPTION
Remove unnecessary session store declarations and persistence, and ensure token retrieval uses the session store in the request interceptor.